### PR TITLE
Fix: Correct Gemini API model name in verifier.html

### DIFF
--- a/verifier.html
+++ b/verifier.html
@@ -298,7 +298,7 @@
             50
           )}...) ---`
         );
-        const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`;
+        const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`;
         const headers = { 'Content-Type': 'application/json' };
         const payload = {
           systemInstruction: { parts: [{ text: system_prompt }] },


### PR DESCRIPTION
Changed the model name from `gemini-1.5-flash-latest` to `gemini-1.5-flash` in the `GEMINI_API_URL` constant to resolve the 404 error when calling the Gemini API.