### PR TITLE
Fix: Update Gemini API endpoint to use a valid model name

### DIFF
--- a/verifier.html
+++ b/verifier.html
@@ -298,7 +298,7 @@
             50
           )}...) ---`
         );
-        const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`;
+        const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-001:generateContent?key=${apiKey}`;
         const headers = { 'Content-Type': 'application/json' };
         const payload = {
           systemInstruction: { parts: [{ text: system_prompt }] },


### PR DESCRIPTION
The application was receiving 404 errors when calling the Gemini API because it was using an incorrect model name ('gemini-1.5-flash'). This change updates the API endpoint to use the correct and more specific model name 'gemini-1.5-flash-001', which resolves the 404 errors and allows the application to function as expected.