### PR TITLE
Fix: Handle citations as sources and update Gemini model

### DIFF
--- a/verifier.html
+++ b/verifier.html
@@ -194,8 +194,8 @@
           if (links && links.length > 0) {
             phase1Html += `<h4 class="text-lg font-semibold mb-2 text-gray-700">Source Link Analysis</h4><ul class="list-disc list-inside space-y-1 text-sm">`;
             links.forEach((link) => {
-              if (link.status === 'Error') {
-                phase1Html += `<li>${link.url} - <span class="font-medium text-red-500">${link.reason}</span></li>`;
+              if (link.type === 'citation') {
+                phase1Html += `<li>${link.text}</li>`;
               } else {
                 phase1Html += `<li><a href="${link.url}" target="_blank" class="text-blue-600 hover:underline">${link.url}</a> - <span class="font-medium">${link.domain_type}</span></li>`;
               }
@@ -388,9 +388,10 @@
         }
 
         _check_source_links() {
-          return this.source_urls.map((url) => {
+          return this.source_urls.map((source) => {
             try {
-              const parsed_url = new URL(url);
+              // Try to parse it as a URL
+              const parsed_url = new URL(source);
               const domain = parsed_url.hostname;
               const tld = domain.split('.').pop();
               let domain_type = 'General/Blog';
@@ -405,12 +406,14 @@
                 domain_type = 'Reputable News Source';
               }
               return {
-                url,
+                type: 'url',
+                url: source,
                 status: 'Domain Analyzed (Live Check N/A)',
                 domain_type,
               };
             } catch (e) {
-              return { url, status: 'Error', reason: 'Invalid URL format' };
+              // If it fails, treat it as a citation.
+              return { type: 'citation', text: source };
             }
           });
         }


### PR DESCRIPTION
This commit resolves two issues:
1.  The application was treating all sources as URLs, causing an "Invalid URL format" error for text-based citations. The source handling logic has been updated to differentiate between URLs and citations, and the rendering logic now displays them appropriately.
2.  The application was using a retired Gemini 1.5 Flash model, which has been updated to the recommended stable version, `gemini-2.0-flash-001`.