### PR TITLE
feat: Add isolated testing for Markup System

### DIFF
--- a/verification_automator.py
+++ b/verification_automator.py
@@ -2,6 +2,7 @@ import requests
 import json
 import time
 from urllib.parse import urlparse
+import argparse
 
 # --- Gemini API Configuration ---
 # The Canvas environment will automatically provide the API key. DO NOT populate this variable.
@@ -230,8 +231,20 @@ class AI_Verification_Assistant:
         print("="*50)
 
 
+    def run_markup_only_verification(self):
+        """Runs only the markup generation and prints the report."""
+        print("--- Starting Markup-Only Process ---")
+        self.verification_report['Markup System'] = self.generate_markup()
+        print("\n--- Markup Process Complete ---")
+        self.print_report()
+
+
 # --- EXAMPLE USAGE ---
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='AI-Assisted Verification Tool.')
+    parser.add_argument('--markup-only', action='store_true', help='Run only the markup generation process.')
+    args = parser.parse_args()
+
     mock_article = """
     Silicon Valley, CA - In a landmark announcement, global tech giant Innovate Inc. launched its revolutionary 'Quantum' smartphone today.
     The device, which is set to dominate the market, features a new 'Photonic' chip, promising a 50% increase in processing speed.
@@ -240,10 +253,14 @@ if __name__ == "__main__":
     Sources claim 1,000,000 units will be available at launch on October 26th. A new claim not in the sources is that the phone is made of titanium.
     """
     mock_source_list = [
-        "https://www.reuters.com/innovate-inc-press-release",
-        "https://www.wsj.com/tech/new-photonic-chip-details",
+        "https.reuters.com/innovate-inc-press-release",
+        "https.wsj.com/tech/new-photonic-chip-details",
         "Dr. Evelyn Reed, a leading expert in photonic technology",
         "The 2023 Annual Report on Semiconductor Advances"
     ]
+
     assistant = AI_Verification_Assistant(mock_article, mock_source_list)
-    assistant.run_full_verification()
+    if args.markup_only:
+        assistant.run_markup_only_verification()
+    else:
+        assistant.run_full_verification()

--- a/verifier.html
+++ b/verifier.html
@@ -98,12 +98,20 @@
                 placeholder="Paste your API key here"
               />
             </div>
-            <button
-              id="verify-button"
-              class="w-full bg-blue-600 text-white font-bold py-3 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-150 ease-in-out"
-            >
-              Verify Article
-            </button>
+            <div class="flex space-x-2">
+              <button
+                id="verify-button"
+                class="w-full bg-blue-600 text-white font-bold py-3 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-150 ease-in-out"
+              >
+                Verify Article
+              </button>
+              <button
+                id="markup-button"
+                class="w-full bg-green-600 text-white font-bold py-3 px-4 rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition duration-150 ease-in-out"
+              >
+                Markup Only
+              </button>
+            </div>
 
             <div id="status-container" class="mt-4 text-center">
               <div
@@ -131,6 +139,7 @@
 
     <script>
       const verifyButton = document.getElementById('verify-button');
+      const markupButton = document.getElementById('markup-button');
       const articleInput = document.getElementById('article-input');
       const sourcesInput = document.getElementById('sources-input');
       const apiKeyInput = document.getElementById('api-key-input');
@@ -161,6 +170,8 @@
         loader.classList.remove('hidden');
         verifyButton.disabled = true;
         verifyButton.classList.add('opacity-50', 'cursor-not-allowed');
+        markupButton.disabled = true;
+        markupButton.classList.add('opacity-50', 'cursor-not-allowed');
 
         const assistant = new AI_Verification_Assistant(
           articleText,
@@ -175,9 +186,52 @@
         loader.classList.add('hidden');
         statusText.textContent = 'Verification Complete!';
 
-        // Re-enable button
+        // Re-enable buttons
         verifyButton.disabled = false;
         verifyButton.classList.remove('opacity-50', 'cursor-not-allowed');
+        markupButton.disabled = false;
+        markupButton.classList.remove('opacity-50', 'cursor-not-allowed');
+      });
+
+      markupButton.addEventListener('click', async () => {
+        const apiKey = apiKeyInput.value.trim();
+        const articleText = articleInput.value.trim();
+
+        if (!apiKey) {
+          alert('Please provide your Gemini API key to continue.');
+          return;
+        }
+        if (!articleText) {
+          alert('Please provide an article to markup.');
+          return;
+        }
+
+        // Reset UI
+        reportOutput.classList.add('hidden');
+        loader.classList.remove('hidden');
+        verifyButton.disabled = true;
+        verifyButton.classList.add('opacity-50', 'cursor-not-allowed');
+        markupButton.disabled = true;
+        markupButton.classList.add('opacity-50', 'cursor-not-allowed');
+
+        const assistant = new AI_Verification_Assistant(
+          articleText,
+          [], // No sources needed for markup only
+          apiKey
+        );
+        const report = await assistant.run_markup_only_verification();
+
+        // Render and Display report
+        renderHtmlReport(report);
+        reportOutput.classList.remove('hidden');
+        loader.classList.add('hidden');
+        statusText.textContent = 'Markup Complete!';
+
+        // Re-enable buttons
+        verifyButton.disabled = false;
+        verifyButton.classList.remove('opacity-50', 'cursor-not-allowed');
+        markupButton.disabled = false;
+        markupButton.classList.remove('opacity-50', 'cursor-not-allowed');
       });
 
       function renderHtmlReport(report) {
@@ -321,6 +375,12 @@
           statusText.textContent = 'Generating Markup...';
           this.verification_report['Markup System'] = await this.generate_markup();
 
+          return this.verification_report;
+        }
+
+        async run_markup_only_verification() {
+          statusText.textContent = 'Generating Markup...';
+          this.verification_report['Markup System'] = await this.generate_markup();
           return this.verification_report;
         }
 


### PR DESCRIPTION
This commit introduces the ability to test the new Markup System in isolation, both through the web interface and the command line.

- Adds a "Markup Only" button to `verifier.html` which triggers only the markup generation.
- Adds a `--markup-only` flag to `verification_automator.py` to run only the markup generation from the command line.
- Creates new methods `run_markup_only_verification` in both the Python and JavaScript classes to handle the isolated logic.